### PR TITLE
Grant additional permissions to the postgres user

### DIFF
--- a/templates/ansible/roles/postgresql/tasks/main.yml
+++ b/templates/ansible/roles/postgresql/tasks/main.yml
@@ -10,7 +10,7 @@
   pip: name=psycopg2
 
 - name: Create postgresql user
-  postgresql_user: name={{ postgresql_db_user }} password={{ postgresql_db_password }} role_attr_flags=CREATEDB
+  postgresql_user: name={{ postgresql_db_user }} password={{ postgresql_db_password }} role_attr_flags=CREATEDB,SUPERUSER,CREATEROLE
   sudo_user: postgres
 
 - name: Create postgresql database


### PR DESCRIPTION
Before
```sql
vagrant=# select * from pg_user;
 usename  | usesysid | usecreatedb | usesuper | usecatupd | userepl |  passwd  |
----------+----------+-------------+----------+-----------+---------+----------+
 postgres |       10 | t           | t        | t         | t       | ******** |
 vagrant  |    16384 | t           | f        | f         | f       | ******** |
(2 rows)
```

After
```sql
vagrant=# select * from pg_user;
 usename  | usesysid | usecreatedb | usesuper | usecatupd | userepl |  passwd  |
----------+----------+-------------+----------+-----------+---------+----------+
 postgres |       10 | t           | t        | t         | t       | ******** |
 vagrant  |    16384 | t           | t        | t         | f       | ******** |
(2 rows)
```

## Why?
I'm working on a Rails 3.x.x project which uses the hstore extension.
The extension installs correctly on the `development` database, but when I try to run `rake db:test:prepare` the hstore extension can't be installed on the `test` database due to lack of permissions for the Vagrant Postgres user.