### PR TITLE
Refactor secure id generation

### DIFF
--- a/app/models/box.rb
+++ b/app/models/box.rb
@@ -8,7 +8,7 @@ class Box < ActiveRecord::Base
   before_validation :generate_secure_id, on: :create
 
   def self.background_jobs
-    [ OpenStruct.new({ id: 'delayed_job', name: 'delayed_job' }), 
+    [ OpenStruct.new({ id: 'delayed_job', name: 'delayed_job' }),
       OpenStruct.new({ id: 'sidekiq',     name: 'sidekiq' }),
       OpenStruct.new({ id: 'resque',      name: 'resque' }), ]
   end
@@ -24,6 +24,9 @@ class Box < ActiveRecord::Base
   private
 
   def generate_secure_id
-    self.secure_id = SecureIdGenerator.generate
+    loop do
+      self.secure_id = SecureIdGenerator.generate
+      break unless self.class.exists?(secure_id: secure_id)
+    end
   end
 end

--- a/spec/models/box_spec.rb
+++ b/spec/models/box_spec.rb
@@ -5,16 +5,18 @@ describe Box do
   it { should allow_value('my-app').for(:vm_name) }
 
   describe 'secure_id' do
-    before { allow(SecureIdGenerator).to receive(:generate) { 'abc123' } }
+    let(:params) { { params: {databases: []} } }
 
-    it 'does not allows non-unique secure id' do
-      described_class.create!(params: {databases: []})
-      expect(described_class.create(params: {databases: []})).not_to be_valid
-    end
+    before { allow(SecureIdGenerator).to receive(:generate) { '123' } }
 
     it 'generates unique secure id' do
-      box = described_class.create!(params: {databases: []})
-      expect(box.secure_id).to eq 'abc123'
+      box = described_class.create!(params)
+      expect(box.secure_id).to eql '123'
+    end
+
+    it 'checks the uniqueness of secure id' do
+      allow(described_class).to receive(:exists?).with({secure_id: '123'})
+      described_class.create!(params)
     end
   end
 


### PR DESCRIPTION
Every time a `Box` is created, it will try to generate a non-duplicate `secure_id`. This will prevent the app from crashing in the case that the `secure_id` is duplicate.