### PR TITLE
Fix RVM Yaml Syntax Error

### DIFF
--- a/templates/ansible/roles/ruby/tasks/rvm.yml
+++ b/templates/ansible/roles/ruby/tasks/rvm.yml
@@ -71,7 +71,7 @@
   when: install_rubies.results[0].rc != 0 and item.rc != 0
   with_items: detect_rubies.results
   sudo_user: '{{ rvm1_user }}'
-.
+
 - name: Detect default ruby version
   command: '{{ rvm1_rvm }} alias list default'
   changed_when: False


### PR DESCRIPTION
This fixes the error below which I was receiving when trying to provision

```
/provision.sh
ERROR: Syntax Error while loading YAML script, /Users/mikeastock/code/fantasynews-rails/railsbox/ansible/roles/ruby/tasks/rvm.yml
Note: The error may actually appear before this position: line 75, column 1

.
- name: Detect default ruby version
```