### PR TITLE
Reversed order of check for RVM non-binary

### DIFF
--- a/templates/ansible/roles/ruby/tasks/rvm.yml
+++ b/templates/ansible/roles/ruby/tasks/rvm.yml
@@ -68,7 +68,7 @@
 # https://github.com/andreychernih/railsbox/issues/13
 - name: Install rubies (non-binary)
   command: '{{ rvm1_rvm }} install {{ item.item }}'
-  when: install_rubies.results[0].rc != 0 and item.rc != 0
+  when: item.rc != 0 && install_rubies.results[0].rc != 0
   with_items: detect_rubies.results
   sudo_user: '{{ rvm1_user }}'
 


### PR DESCRIPTION
If you provision once with a failure but past this step, then provision again, line 71 will fail. Reversing the order of the when clause succeeds because item.rc will not equal zero but install_rubies results will be empty and skipped because the first part of the and check fails so the second statement doesnt evaluate.