### PR TITLE
resolves #37, jinja if conditional without else returns undefined

### DIFF
--- a/templates/ansible/group_vars/all/config.yml.erb
+++ b/templates/ansible/group_vars/all/config.yml.erb
@@ -20,7 +20,7 @@ user_home_path: '/home/{{ user_name }}'
 ssl_certificate_path: /etc/nginx/ssl/{{ server_name }}.crt
 ssl_certificate_key_path: /etc/nginx/ssl/{{ server_name }}.key
 
-app_path: '{{ path }}{{ "/current" if target != "virtualbox" }}'
+app_path: '{{ path }}{{ "/current" if target != "virtualbox" else "" }}'
 app_public_path: "{{ app_path }}/public"
 app_config_path: '{{ app_path if target == "virtualbox" else shared_path }}/config'
 app_temp_path: "/tmp{{ app_path }}"


### PR DESCRIPTION
See #37 - when the conditional was evaluating to false, jinja returns an undefined object.
From http://jinja.pocoo.org/docs/dev/templates/#if-expression
> The else part is optional. If not provided, the else block implicitly evaluates into an undefined object