### PR TITLE
Assure app config initializers directory exists in redis task

### DIFF
--- a/templates/ansible/roles/redis/tasks/main.yml
+++ b/templates/ansible/roles/redis/tasks/main.yml
@@ -11,10 +11,13 @@
 - name: Enable and start redis-server
   service: name=redis-server enabled=yes state=started
 
+- name: Assure initializers dir exists
+  file: path={{app_config_path}}/initializers state=directory
+
 - name: Configure redis-rb
   template: src=redis.rb.j2 dest={{ app_config_path }}/initializers/redis.rb owner={{ user_name }} backup=yes
   when: redis_orm is defined and redis_orm == 'redis-rb'
- 
+
 - name: Create upstart config
   template: src=upstart.conf.j2 dest=/etc/init/redis.conf
   notify: restart redis


### PR DESCRIPTION
Hey Folks,

Came across the following issue when provisioning a staging environment. Admittedly I am fairly new to both this tool (which is great btw!) and Ansible, but this adds a task that assures the directory exists before attempting to move the file across.  

```shell
TASK [base : Configure redis-rb] ******************************************
fatal: [188.166.148.221]: FAILED! => {"changed": false, "failed": true, "msg": "Destination directory /rails_app/shared/config/initializers does not exist"} 
```

Hope this helps!