### PR TITLE
Updated Postgres task to create a test DB

### DIFF
--- a/templates/ansible/roles/postgresql/tasks/main.yml.erb
+++ b/templates/ansible/roles/postgresql/tasks/main.yml.erb
@@ -35,6 +35,10 @@
   postgresql_db: name={{ postgresql_db_name }} owner={{ postgresql_db_user }}
   sudo_user: postgres
 
+- name: Create postgresql test database
+  postgresql_db: name={{ postgresql_db_name }}_test owner={{ postgresql_db_user }}
+  sudo_user: postgres
+
 - name: Assure that config dir exists
   file: path={{ shared_config_path }} state=directory
 


### PR DESCRIPTION
Not sure if we want to be doing this or not, but Rails 5.0.0.beta3 fails to do the create and migrate DB due to the test DB being missing ...