### PR TITLE
Shift to bundling all Gems into the vendor path

### DIFF
--- a/templates/ansible/roles/ruby/tasks/main.yml
+++ b/templates/ansible/roles/ruby/tasks/main.yml
@@ -13,6 +13,6 @@
   sudo_user: '{{ ruby_user_name }}'
 
 - name: bundle install
-  command: /bin/bash -l -c 'bundle install' chdir={{ app_path }}
+  command: /bin/bash -l -c 'bundle install --path vendor/bundle' chdir={{ app_path }}
   sudo_user: '{{ ruby_user_name }}'
   when: target == 'virtualbox'


### PR DESCRIPTION
Not sure if you want to do this as a default or not, but from what I can tell, this is considered good practice?