### PR TITLE
Add shell wrapper for Vagrant

### DIFF
--- a/templates/environment/virtualbox/deploy.sh
+++ b/templates/environment/virtualbox/deploy.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+vagrant up

--- a/templates/environment/virtualbox/provision.sh
+++ b/templates/environment/virtualbox/provision.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+vagrant up --provision


### PR DESCRIPTION
The goal here is to make launching the vagrant version the same
style as deploying a web version. This parallelism makes it easier
to write instructions and easier to create automation. It also
links the idea that provisioning for Vagrant is parallel to provisioning
the server, while deploying the code is parallel to just turning the
vagrant image up.

Came up as part of work on https://github.com/notch8/railsbox-tasks 
a set of tasks to make working with a railsboxed app easier.